### PR TITLE
Fix config: test for either .a or .dylib libs

### DIFF
--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ else
 	done
 
 	for lib in capnp kj; do
-		test -f "$(brew --prefix)/lib/lib${lib}.a" || error "*** dependency missing: ‘$(brew --prefix)/lib/lib${lib}.a’. Install dependency and/or update ‘local.rave’ with correct path."
+		test -f "$(brew --prefix)/lib/lib${lib}.dylib" || error "*** dependency missing: ‘$(brew --prefix)/lib/lib${lib}.a’. Install dependency and/or update ‘local.rave’ with correct path."
 	done
 fi
 

--- a/configure
+++ b/configure
@@ -21,8 +21,9 @@ else
 	done
 
 	for lib in capnp kj; do
-		test -f "$(brew --prefix)/lib/lib${lib}.dylib" || error "*** dependency missing: ‘$(brew --prefix)/lib/lib${lib}.a’. Install dependency and/or update ‘local.rave’ with correct path."
-	done
+		test -f "$(brew --prefix)/lib/lib${lib}.dylib" || test -f "$(brew --prefix)/lib/lib${lib}.a" \
+		|| error "*** dependency missing: ‘$(brew --prefix)/lib/lib${lib}.{dylib,a}’. Install dependency and/or update ‘local.rave’ with correct path."
+done
 fi
 
 # ========================


### PR DESCRIPTION
In `.configure` checks, changed lib extension from `.a` to `.dylib`, allowing successful config + build.